### PR TITLE
fix formatting for nvim version 0.9.0

### DIFF
--- a/nvim/lua/user/plugins/lspconfig.lua
+++ b/nvim/lua/user/plugins/lspconfig.lua
@@ -1,76 +1,76 @@
 -- Setup Mason to automatically install LSP servers
-require('mason').setup()
-require('mason-lspconfig').setup({ automatic_installation = true })
+require("mason").setup()
+require("mason-lspconfig").setup({ automatic_installation = true })
 
-local capabilities = require('cmp_nvim_lsp').update_capabilities(vim.lsp.protocol.make_client_capabilities())
+local capabilities = require("cmp_nvim_lsp").update_capabilities(vim.lsp.protocol.make_client_capabilities())
 
 -- PHP
-require('lspconfig').intelephense.setup({ capabilities = capabilities })
+require("lspconfig").intelephense.setup({ capabilities = capabilities })
 
 -- Vue, JavaScript, TypeScript
-require('lspconfig').volar.setup({
-  capabilities = capabilities,
-  -- Enable "Take Over Mode" where volar will provide all JS/TS LSP services
-  -- This drastically improves the responsiveness of diagnostic updates on change
-  filetypes = { 'typescript', 'javascript', 'javascriptreact', 'typescriptreact', 'vue' },
+require("lspconfig").volar.setup({
+	capabilities = capabilities,
+	-- Enable "Take Over Mode" where volar will provide all JS/TS LSP services
+	-- This drastically improves the responsiveness of diagnostic updates on change
+	filetypes = { "typescript", "javascript", "javascriptreact", "typescriptreact", "vue" },
 })
 
 -- Tailwind CSS
-require('lspconfig').tailwindcss.setup({ capabilities = capabilities })
+require("lspconfig").tailwindcss.setup({ capabilities = capabilities })
 
 -- JSON
-require('lspconfig').jsonls.setup({
-  capabilities = capabilities,
-  settings = {
-    json = {
-      schemas = require('schemastore').json.schemas(),
-    },
-  },
+require("lspconfig").jsonls.setup({
+	capabilities = capabilities,
+	settings = {
+		json = {
+			schemas = require("schemastore").json.schemas(),
+		},
+	},
 })
 
 -- null-ls
-require('null-ls').setup({
-  sources = {
-    require('null-ls').builtins.diagnostics.eslint_d.with({
-      condition = function(utils)
-        return utils.root_has_file({ '.eslintrc.js' })
-      end,
-    }),
-    require('null-ls').builtins.diagnostics.trail_space.with({ disabled_filetypes = { 'NvimTree' } }),
-    require('null-ls').builtins.formatting.eslint_d.with({
-      condition = function(utils)
-        return utils.root_has_file({ '.eslintrc.js' })
-      end,
-    }),
-    require('null-ls').builtins.formatting.prettierd,
-  },
+require("null-ls").setup({
+	sources = {
+		require("null-ls").builtins.diagnostics.eslint_d.with({
+			condition = function(utils)
+				return utils.root_has_file({ ".eslintrc.js" })
+			end,
+		}),
+		require("null-ls").builtins.diagnostics.trail_space.with({ disabled_filetypes = { "NvimTree" } }),
+		require("null-ls").builtins.formatting.eslint_d.with({
+			condition = function(utils)
+				return utils.root_has_file({ ".eslintrc.js" })
+			end,
+		}),
+		require("null-ls").builtins.formatting.prettierd,
+	},
 })
 
-require('mason-null-ls').setup({ automatic_installation = true })
+require("mason-null-ls").setup({ automatic_installation = true })
 
 -- Keymaps
-vim.keymap.set('n', '<Leader>d', '<cmd>lua vim.diagnostic.open_float()<CR>')
-vim.keymap.set('n', '[d', '<cmd>lua vim.diagnostic.goto_prev()<CR>')
-vim.keymap.set('n', ']d', '<cmd>lua vim.diagnostic.goto_next()<CR>')
-vim.keymap.set('n', 'gd', '<cmd>lua vim.lsp.buf.definition()<CR>')
-vim.keymap.set('n', 'gi', ':Telescope lsp_implementations<CR>')
-vim.keymap.set('n', 'gr', ':Telescope lsp_references<CR>')
-vim.keymap.set('n', 'K', '<cmd>lua vim.lsp.buf.hover()<CR>')
-vim.keymap.set('n', '<Leader>rn', '<cmd>lua vim.lsp.buf.rename()<CR>')
+vim.keymap.set("n", "<Leader>d", "<cmd>lua vim.diagnostic.open_float()<CR>")
+vim.keymap.set("n", "[d", "<cmd>lua vim.diagnostic.goto_prev()<CR>")
+vim.keymap.set("n", "]d", "<cmd>lua vim.diagnostic.goto_next()<CR>")
+vim.keymap.set("n", "gd", "<cmd>lua vim.lsp.buf.definition()<CR>")
+vim.keymap.set("n", "gi", ":Telescope lsp_implementations<CR>")
+vim.keymap.set("n", "gr", ":Telescope lsp_references<CR>")
+vim.keymap.set("n", "K", "<cmd>lua vim.lsp.buf.hover()<CR>")
+vim.keymap.set("n", "<Leader>rn", "<cmd>lua vim.lsp.buf.rename()<CR>")
 
 -- Commands
-vim.api.nvim_create_user_command('Format', vim.lsp.buf.formatting, {})
+vim.api.nvim_create_user_command("Format", vim.lsp.buf.format, {})
 
 -- Diagnostic configuration
 vim.diagnostic.config({
-  virtual_text = false,
-  float = {
-    source = true,
-  }
+	virtual_text = false,
+	float = {
+		source = true,
+	},
 })
 
 -- Sign configuration
-vim.fn.sign_define('DiagnosticSignError', { text = '', texthl = 'DiagnosticSignError' })
-vim.fn.sign_define('DiagnosticSignWarn', { text = '', texthl = 'DiagnosticSignWarn' })
-vim.fn.sign_define('DiagnosticSignInfo', { text = '', texthl = 'DiagnosticSignInfo' })
-vim.fn.sign_define('DiagnosticSignHint', { text = '', texthl = 'DiagnosticSignHint' })
+vim.fn.sign_define("DiagnosticSignError", { text = "", texthl = "DiagnosticSignError" })
+vim.fn.sign_define("DiagnosticSignWarn", { text = "", texthl = "DiagnosticSignWarn" })
+vim.fn.sign_define("DiagnosticSignInfo", { text = "", texthl = "DiagnosticSignInfo" })
+vim.fn.sign_define("DiagnosticSignHint", { text = "", texthl = "DiagnosticSignHint" })


### PR DESCRIPTION
## What?

Fix formatting for nvim version 0.9.0

## Why?

While configuring vim i got the following error 

`error executing lua [string":lua"]:1 attemp to call field 'formatting_sync' ( a nil vlaue) stack traceback: [string ":lua"]:1: in main chunk` 

So after doing some digging I read this post on reddit [https://www.reddit.com/r/neovim/comments/wnkdoa/comment/ikcsqca/?utm_source=share&utm_medium=web3x](url) and figured out some nvim version gives the above error while using `vim.lsp.buf.formatting` command 

## How?

This now has fixed formatting by using `vim.lsp.buf.format`
